### PR TITLE
Update deprecated syntax for future rstan compatibility

### DIFF
--- a/inst/stan/BAM.stan
+++ b/inst/stan/BAM.stan
@@ -2,15 +2,15 @@ data {
   int<lower = 1> N;                       // n of individuals
   int<lower = 1> J;                       // n of items
   int<lower = 1> N_obs;                   // n of observations
-  int<lower = 1> ii[N_obs];               // index i in matrix
-  int<lower = 1> jj[N_obs];               // index j in matrix
+  array[N_obs] int<lower = 1> ii;               // index i in matrix
+  array[N_obs] int<lower = 1> jj;               // index j in matrix
   int<lower = 1> B;                       // length of scale -1 / 2
   int<lower = 1, upper = J> L;            // left pole
   int<lower = 1, upper = J> R;            // right pole
-  int<lower = -B, upper = B>  Y[N_obs];   // reported stimuli positions
+  array[N_obs] int<lower = -B, upper = B>  Y;   // reported stimuli positions
   vector<lower = -B, upper = B>[N] V;     // reported self-placements
   int<lower=0, upper=1> CV;               // indicator of cross-validation
-  int<lower=0, upper=1> holdout[N_obs];   // holdout for cross-validation
+  array[N_obs] int<lower=0, upper=1> holdout;   // holdout for cross-validation
 }
 
 transformed data {
@@ -22,7 +22,7 @@ parameters {
   vector[N] beta;                         // stretch parameter
   real<lower = -1.1, upper = -.9> thetal; // left pole stimuli
   real<lower = .9, upper = 1.1> thetar;   // right pole stimuli
-  real theta_raw[J];                      // remaining stimuli
+  array[J] real theta_raw;                      // remaining stimuli
   real<lower = 3, upper = 30> nu;         // concentration of etas
   real<lower = 0> tau;                    // scale of errors
   vector<lower = 0>[N] eta;               // mean ind. error variance x J^2
@@ -30,7 +30,7 @@ parameters {
 }
 
 transformed parameters {
-  real theta[J];                          // latent stimuli position
+  array[J] real theta;                          // latent stimuli position
   vector[N_obs] log_lik;                  // pointwise log-likelihood
   real<lower = 0> eta_scale = tau * J;
   theta = theta_raw;

--- a/inst/stan/FBAM_MINI.stan
+++ b/inst/stan/FBAM_MINI.stan
@@ -2,15 +2,15 @@ data {
   int<lower = 1> N;                       // n of individuals
   int<lower = 1> J;                       // n of items
   int<lower = 1> N_obs;                   // n of observations
-  int<lower = 1> ii[N_obs];               // index i in matrix
-  int<lower = 1> jj[N_obs];               // index j in matrix
+  array[N_obs] int<lower = 1> ii;               // index i in matrix
+  array[N_obs] int<lower = 1> jj;               // index j in matrix
   int<lower = 1> B;                       // length of scale -1 / 2
   int<lower = 1, upper = J> L;            // left pole
   int<lower = 1, upper = J> R;            // right pole
-  int<lower = -B, upper = B> Y[N_obs];    // reported stimuli positions
+  array[N_obs] int<lower = -B, upper = B> Y;    // reported stimuli positions
   vector<lower = -B, upper = B>[N] V;     // reported self-placements
   int<lower=0, upper=1> CV;               // indicator of cross-validation
-  int<lower=0, upper=1> holdout[N_obs];   // holdout for cross-validation
+  array[N_obs] int<lower=0, upper=1> holdout;   // holdout for cross-validation
 }
 
 transformed data {
@@ -25,7 +25,7 @@ parameters {
   matrix[N, 2] alpha_raw;                 // shift parameter, split, raw
   matrix[N, 2] beta_raw;                  // stretch parameter, split, raw
   ordered[2] theta_lr;                    // left and right pole
-  real theta_raw[J];                      // remaining stimuli
+  array[J] real theta_raw;                      // remaining stimuli
   real<lower = 0> tau;                    // scale of errors
   vector<lower = 0, upper = 1>[N] lambda; // mixing proportion, flipping
 }
@@ -33,7 +33,7 @@ parameters {
 transformed parameters {
   real<lower=0> alpha_lambda = delta * psi; // reparameterization
   real<lower=0> beta_lambda = delta * (1 - psi);
-  real theta[J];                          // latent stimuli position
+  array[J] real theta;                          // latent stimuli position
   matrix[N, 2] alpha0;                    // shift parameter, split
   matrix[N, 2] beta0;                     // stretch parameter, split
   matrix[N, 2] chi0;                      // latent respondent positions, split

--- a/inst/stan/HBAM.stan
+++ b/inst/stan/HBAM.stan
@@ -2,15 +2,15 @@ data {
   int<lower = 1> N;                       // n of individuals
   int<lower = 1> J;                       // n of items
   int<lower = 1> N_obs;                   // n of observations
-  int<lower = 1> ii[N_obs];               // index i in matrix
-  int<lower = 1> jj[N_obs];               // index j in matrix
+  array[N_obs] int<lower = 1> ii;               // index i in matrix
+  array[N_obs] int<lower = 1> jj;               // index j in matrix
   int<lower = 1> B;                       // length of scale -1 / 2
   int<lower = 1, upper = J> L;            // left pole
   int<lower = 1, upper = J> R;            // right pole
-  int<lower = -B, upper = B> Y[N_obs];    // reported stimuli positions
+  array[N_obs] int<lower = -B, upper = B> Y;    // reported stimuli positions
   vector<lower = -B, upper = B>[N] V;     // reported self-placements
   int<lower=0, upper=1> CV;               // indicator of cross-validation
-  int<lower=0, upper=1> holdout[N_obs];   // holdout for cross-validation
+  array[N_obs] int<lower=0, upper=1> holdout;   // holdout for cross-validation
 }
 
 transformed data {
@@ -23,7 +23,7 @@ parameters {
   matrix[N, 2] alpha_raw;                 // shift parameter, split, raw
   matrix[N, 2] beta_raw;                  // stretch parameter, split, raw
   ordered[2] theta_lr;                    // left and right pole
-  real theta_raw[J];                      // remaining stimuli
+  array[J] real theta_raw;                      // remaining stimuli
   real<lower = 0> sigma_alpha;            // sd of alpha
   real<lower = 0, upper = 2> sigma_beta;  // sd of log(beta)
   real<lower = 0> sigma_chi;              // sd of chi0
@@ -40,7 +40,7 @@ parameters {
 transformed parameters {
   real<lower=0> alpha_lambda = delta * psi; // reparameterization
   real<lower=0> beta_lambda = delta * (1 - psi);
-  real theta[J];                          // latent stimuli position
+  array[J] real theta;                          // latent stimuli position
   matrix[N, 2] alpha0;                    // shift parameter, split
   matrix[N, 2] beta0;                     // stretch parameter, split
   vector[N_obs] log_lik;                  // pointwise log-likelihood for Y

--- a/inst/stan/HBAM_0.stan
+++ b/inst/stan/HBAM_0.stan
@@ -2,15 +2,15 @@ data {
   int<lower = 1> N;                       // n of individuals
   int<lower = 1> J;                       // n of items
   int<lower = 1> N_obs;                   // n of observations
-  int<lower = 1> ii[N_obs];               // index i in matrix
-  int<lower = 1> jj[N_obs];               // index j in matrix
+  array[N_obs] int<lower = 1> ii;               // index i in matrix
+  array[N_obs] int<lower = 1> jj;               // index j in matrix
   int<lower = 1> B;                       // length of scale -1 / 2
   int<lower = 1, upper = J> L;            // left pole
   int<lower = 1, upper = J> R;            // right pole
-  int<lower = -B, upper = B> Y[N_obs];    // reported stimuli positions
+  array[N_obs] int<lower = -B, upper = B> Y;    // reported stimuli positions
   vector<lower = -B, upper = B>[N] V;     // reported self-placements
   int<lower=0, upper=1> CV;               // indicator of cross-validation
-  int<lower=0, upper=1> holdout[N_obs];   // holdout for cross-validation
+  array[N_obs] int<lower=0, upper=1> holdout;   // holdout for cross-validation
 }
 
 transformed data {
@@ -23,7 +23,7 @@ parameters {
   vector[N] alpha_raw;                    // shift parameter, raw
   vector[N] beta_raw;                     // stretch parameter, raw
   ordered[2] theta_lr;                    // left and right pole
-  real theta_raw[J];                      // remaining stimuli
+  array[J] real theta_raw;                      // remaining stimuli
   real<lower = 0> sigma_alpha;            // sd of alpha
   real<lower = 0, upper = 2> sigma_beta;  // sd of log(beta)
   real<lower = 0> sigma_chi;              // sd of chi0
@@ -37,7 +37,7 @@ parameters {
 transformed parameters {
   vector[N] alpha;                        // shift parameter
   vector[N] beta;                         // stretch parameter
-  real theta[J];                          // latent stimuli position
+  array[J] real theta;                          // latent stimuli position
   vector[N_obs] log_lik;                  // pointwise log-likelihood for Y
   vector[N] log_lik_V;                    // pointwise log-likelihood for V
   real<lower = 0> eta_scale = tau * J;

--- a/inst/stan/HBAM_2.stan
+++ b/inst/stan/HBAM_2.stan
@@ -2,22 +2,22 @@ data {
   int<lower = 1> N;                       // n of individuals
   int<lower = 1> J;                       // n of items
   int<lower = 1> N_obs;                   // n of observations
-  int<lower = 1> ii[N_obs];               // index i in matrix
-  int<lower = 1> jj[N_obs];               // index j in matrix
+  array[N_obs] int<lower = 1> ii;               // index i in matrix
+  array[N_obs] int<lower = 1> jj;               // index j in matrix
   int<lower = 1> B;                       // length of scale -1 / 2
   int<lower = 1, upper = J> L;            // left pole
   int<lower = 1, upper = J> R;            // right pole
-  int<lower = -B, upper = B> Y[N_obs];    // reported stimuli positions
-  int<lower = -B, upper = B> V[N];        // reported self-placements
+  array[N_obs] int<lower = -B, upper = B> Y;    // reported stimuli positions
+  array[N] int<lower = -B, upper = B> V;        // reported self-placements
   int<lower=0, upper=1> CV;               // indicator of cross-validation
-  int<lower=0, upper=1> holdout[N_obs];   // holdout for cross-validation
+  array[N_obs] int<lower=0, upper=1> holdout;   // holdout for cross-validation
 }
 
 transformed data {
   real<lower = 0> sigma_chi_prior_rate = (5 - 1) / (B / 2.0);
   real<lower = 0> sigma_alpha_prior_rate = (2 - 1) / (B / 5.0);
   real<lower = 0> tau_prior_rate = (2 - 1) / (B / 5.0);
-  int Vi[N];                              // self-placements as indexes
+  array[N] int Vi;                              // self-placements as indexes
   for (i in 1:N) {
     if (V[i] < 0) {
       Vi[i] = V[i] + B + 1;
@@ -32,7 +32,7 @@ parameters {
   vector[B * 2] alpha_mean;               // means of priors on alphas
   matrix[N, 2] beta_raw;                  // stretch parameter, split, raw
   ordered[2] theta_lr;                    // left and right pole
-  real theta_raw[J];                      // remaining stimuli
+  array[J] real theta_raw;                      // remaining stimuli
   real<lower = 0> sigma_alpha;            // sd of alpha
   real<lower = 0, upper = 2> sigma_beta;  // sd of log(beta)
   real<lower = 0> sigma_chi;              // sd of chi0
@@ -49,7 +49,7 @@ parameters {
 transformed parameters {
   real<lower=0> alpha_lambda = delta * psi; // reparameterization
   real<lower=0> beta_lambda = delta * (1 - psi);
-  real theta[J];                          // latent stimuli position
+  array[J] real theta;                          // latent stimuli position
   matrix[N, 2] alpha0;                    // shift parameter, split
   matrix[N, 2] beta0;                     // stretch parameter, split
   vector[N_obs] log_lik;                  // pointwise log-likelihood for Y

--- a/inst/stan/HBAM_HM.stan
+++ b/inst/stan/HBAM_HM.stan
@@ -2,15 +2,15 @@ data {
   int<lower = 1> N;                       // n of individuals
   int<lower = 1> J;                       // n of items
   int<lower = 1> N_obs;                   // n of observations
-  int<lower = 1> ii[N_obs];               // index i in matrix
-  int<lower = 1> jj[N_obs];               // index j in matrix
+  array[N_obs] int<lower = 1> ii;               // index i in matrix
+  array[N_obs] int<lower = 1> jj;               // index j in matrix
   int<lower = 1> B;                       // length of scale -1 / 2
   int<lower = 1, upper = J> L;            // left pole
   int<lower = 1, upper = J> R;            // right pole
-  int<lower = -B, upper = B> Y[N_obs];    // reported stimuli positions
+  array[N_obs] int<lower = -B, upper = B> Y;    // reported stimuli positions
   vector<lower = -B, upper = B>[N] V;     // reported self-placements
   int<lower=0, upper=1> CV;               // indicator of cross-validation
-  int<lower=0, upper=1> holdout[N_obs];   // holdout for cross-validation
+  array[N_obs] int<lower=0, upper=1> holdout;   // holdout for cross-validation
 }
 
 transformed data {
@@ -23,7 +23,7 @@ parameters {
   matrix[N, 2] alpha_raw;                 // shift parameter, split, raw
   matrix[N, 2] beta_raw;                  // stretch parameter, split, raw
   ordered[2] theta_lr;                    // left and right pole
-  real theta_raw[J];                      // remaining stimuli
+  array[J] real theta_raw;                      // remaining stimuli
   real<lower = 0> sigma_alpha;            // sd of alpha
   real<lower = 0, upper = 2> sigma_beta;  // sd of log(beta)
   real<lower = 0> sigma_chi;              // sd of chi0
@@ -37,7 +37,7 @@ parameters {
 transformed parameters {
   real<lower=0> alpha_lambda = delta * psi; // reparameterization
   real<lower=0> beta_lambda = delta * (1 - psi);
-  real theta[J];                          // latent stimuli position
+  array[J] real theta;                          // latent stimuli position
   matrix[N, 2] alpha0;                    // shift parameter, split
   matrix[N, 2] beta0;                     // stretch parameter, split
   vector[N_obs] log_lik;                  // pointwise log-likelihood for Y

--- a/inst/stan/HBAM_MINI.stan
+++ b/inst/stan/HBAM_MINI.stan
@@ -2,15 +2,15 @@ data {
   int<lower = 1> N;                       // n of individuals
   int<lower = 1> J;                       // n of items
   int<lower = 1> N_obs;                   // n of observations
-  int<lower = 1> ii[N_obs];               // index i in matrix
-  int<lower = 1> jj[N_obs];               // index j in matrix
+  array[N_obs] int<lower = 1> ii;               // index i in matrix
+  array[N_obs] int<lower = 1> jj;               // index j in matrix
   int<lower = 1> B;                       // length of scale -1 / 2
   int<lower = 1, upper = J> L;            // left pole
   int<lower = 1, upper = J> R;            // right pole
-  int<lower = -B, upper = B> Y[N_obs];    // reported stimuli positions
+  array[N_obs] int<lower = -B, upper = B> Y;    // reported stimuli positions
   vector<lower = -B, upper = B>[N] V;     // reported self-placements
   int<lower=0, upper=1> CV;               // indicator of cross-validation
-  int<lower=0, upper=1> holdout[N_obs];   // holdout for cross-validation
+  array[N_obs] int<lower=0, upper=1> holdout;   // holdout for cross-validation
 }
 
 transformed data {
@@ -22,7 +22,7 @@ parameters {
   matrix[N, 2] alpha_raw;                 // shift parameter, split, raw
   matrix[N, 2] beta_raw;                  // stretch parameter, split, raw
   ordered[2] theta_lr;                    // left and right pole
-  real theta_raw[J];                      // remaining stimuli
+  array[J] real theta_raw;                      // remaining stimuli
   real<lower = 0> sigma_alpha;            // sd of alpha
   real<lower = 0, upper = 2> sigma_beta;  // sd of log(beta)
   real<lower = 0> tau;                    // sd of errors
@@ -34,7 +34,7 @@ parameters {
 transformed parameters {
   real<lower=0> alpha_lambda = delta * psi; // reparameterization
   real<lower=0> beta_lambda = delta * (1 - psi);
-  real theta[J];                          // latent stimuli position
+  array[J] real theta;                          // latent stimuli position
   matrix[N, 2] alpha0;                    // shift parameter, split
   matrix[N, 2] beta0;                     // stretch parameter, split
   matrix[N, 2] chi0;                      // latent respondent positions, split

--- a/inst/stan/HBAM_NE.stan
+++ b/inst/stan/HBAM_NE.stan
@@ -2,15 +2,15 @@ data {
   int<lower = 1> N;                       // n of individuals
   int<lower = 1> J;                       // n of items
   int<lower = 1> N_obs;                   // n of observations
-  int<lower = 1> ii[N_obs];               // index i in matrix
-  int<lower = 1> jj[N_obs];               // index j in matrix
+  array[N_obs] int<lower = 1> ii;               // index i in matrix
+  array[N_obs] int<lower = 1> jj;               // index j in matrix
   int<lower = 1> B;                       // length of scale -1 / 2
   int<lower = 1, upper = J> L;            // left pole
   int<lower = 1, upper = J> R;            // right pole
-  int<lower = -B, upper = B> Y[N_obs];    // reported stimuli positions
+  array[N_obs] int<lower = -B, upper = B> Y;    // reported stimuli positions
   vector<lower = -B, upper = B>[N] V;     // reported self-placements
   int<lower=0, upper=1> CV;               // indicator of cross-validation
-  int<lower=0, upper=1> holdout[N_obs];   // holdout for cross-validation
+  array[N_obs] int<lower=0, upper=1> holdout;   // holdout for cross-validation
 }
 
 transformed data {
@@ -22,7 +22,7 @@ parameters {
   matrix[N, 2] alpha_raw;                 // shift parameter, split, raw
   matrix[N, 2] beta_raw;                  // stretch parameter, split, raw
   ordered[2] theta_lr;                    // left and right pole
-  real theta_raw[J];                      // remaining stimuli
+  array[J] real theta_raw;                      // remaining stimuli
   real<lower = 0> sigma_alpha;            // sd of alpha
   real<lower = 0, upper = 2> sigma_beta;  // sd of log(beta)
   real<lower = 3, upper = 30> nu;         // concentration of etas
@@ -37,7 +37,7 @@ parameters {
 transformed parameters {
   real<lower=0> alpha_lambda = delta * psi; // reparameterization
   real<lower=0> beta_lambda = delta * (1 - psi);
-  real theta[J];                          // latent stimuli position
+  array[J] real theta;                          // latent stimuli position
   matrix[N, 2] alpha0;                    // shift parameter, split
   matrix[N, 2] beta0;                     // stretch parameter, split
   matrix[N, 2] chi0;                      // latent respondent positions, split

--- a/inst/stan/HBAM_R.stan
+++ b/inst/stan/HBAM_R.stan
@@ -2,16 +2,16 @@ data {
   int<lower = 1> N;                       // n of individuals
   int<lower = 1> J;                       // n of items
   int<lower = 1> N_obs;                   // n of observations
-  int<lower = 1> ii[N_obs];               // index i in matrix
-  int<lower = 1> jj[N_obs];               // index j in matrix
+  array[N_obs] int<lower = 1> ii;               // index i in matrix
+  array[N_obs] int<lower = 1> jj;               // index j in matrix
   int<lower = 1> B;                       // length of scale -1 / 2
   int<lower = 1, upper = J> L;            // left pole
   int<lower = 1, upper = J> R;            // right pole
-  int<lower = -B, upper = B> Y[N_obs];    // reported stimuli positions
-  real<lower = 0, upper = 1> U[N_obs];    // reported voter preferences
-  int<lower = -B, upper = B> V[N];        // reported voter positions
+  array[N_obs] int<lower = -B, upper = B> Y;    // reported stimuli positions
+  array[N_obs] real<lower = 0, upper = 1> U;    // reported voter preferences
+  array[N] int<lower = -B, upper = B> V;        // reported voter positions
   int<lower=0, upper=1> CV;               // indicator of cross-validation
-  int<lower=0, upper=1> holdout[N_obs];   // holdout for cross-validation
+  array[N_obs] int<lower=0, upper=1> holdout;   // holdout for cross-validation
 }
 
 transformed data {
@@ -19,7 +19,7 @@ transformed data {
   real<lower = 0> sigma_alpha_prior_rate = (2 - 1) / (B / 5.0);
   real<lower = 0> tau_prior_rate = (2 - 1) / (B / 5.0);
   vector<lower = -B, upper = B>[N] Vvec = to_vector(V);
-  real<lower = -B, upper = B> p[2, N_obs];
+  array[2, N_obs] real<lower = -B, upper = B> p;
   for (n in 1:N_obs) {
     p[1, n] = U[n] * V[ii[n]] + B * U[n] - B;
     p[2, n] = U[n] * V[ii[n]] - B * U[n] + B;
@@ -30,7 +30,7 @@ parameters {
   matrix[N, 2] alpha_raw;                 // shift parameter, split, raw
   matrix[N, 2] beta_raw;                  // stretch parameter, split, raw
   ordered[2] theta_lr;                    // left and right pole
-  real theta_raw[J];                      // remaining stimuli
+  array[J] real theta_raw;                      // remaining stimuli
   real<lower = 0> sigma_alpha;            // sd of alpha
   real<lower = 0, upper = 2> sigma_beta;  // sd of log(beta)
   real<lower = 0> sigma_chi;              // sd of chi0
@@ -42,7 +42,7 @@ parameters {
   real<lower = .5, upper = 1> psi;        // mean of prior on lambda
   real<lower = 2, upper = 100> delta;     // concentration of prior on lambda
   matrix[N, 2] chi0;                      // latent respondent positions, split
-  real<lower = 0, upper = 1> gamma[N];    // rationalization per respondent
+  array[N] real<lower = 0, upper = 1> gamma;    // rationalization per respondent
   real<lower = 1> gam_a;                  // hyperparameter for gamma
   real<lower = 1> gam_b;                  // hyperparameter for gamma
   vector<lower = 0, upper = 1>[2 * B + 1] zeta; // direction of rationalization
@@ -52,7 +52,7 @@ transformed parameters {
   vector[4] log_probs;
   real<lower=0> alpha_lambda = delta * psi; // reparameterization
   real<lower=0> beta_lambda = delta * (1 - psi);
-  real theta[J];                          // latent stimuli position
+  array[J] real theta;                          // latent stimuli position
   matrix[N, 2] alpha0;                    // shift parameter, split
   matrix[N, 2] beta0;                     // stretch parameter, split
   vector[2] mu0;                          // dif-adjusted mean

--- a/inst/stan/HBAM_R_MINI.stan
+++ b/inst/stan/HBAM_R_MINI.stan
@@ -2,23 +2,23 @@ data {
   int<lower = 1> N;                       // n of individuals
   int<lower = 1> J;                       // n of items
   int<lower = 1> N_obs;                   // n of observations
-  int<lower = 1> ii[N_obs];               // index i in matrix
-  int<lower = 1> jj[N_obs];               // index j in matrix
+  array[N_obs] int<lower = 1> ii;               // index i in matrix
+  array[N_obs] int<lower = 1> jj;               // index j in matrix
   int<lower = 1> B;                       // length of scale -1 / 2
   int<lower = 1, upper = J> L;            // left pole
   int<lower = 1, upper = J> R;            // right pole
-  int<lower = -B, upper = B> Y[N_obs];    // reported stimuli positions
-  real<lower = 0, upper = 1> U[N_obs];    // reported voter preferences
-  int<lower = -B, upper = B> V[N];        // reported voter positions
+  array[N_obs] int<lower = -B, upper = B> Y;    // reported stimuli positions
+  array[N_obs] real<lower = 0, upper = 1> U;    // reported voter preferences
+  array[N] int<lower = -B, upper = B> V;        // reported voter positions
   int<lower=0, upper=1> CV;               // indicator of cross-validation
-  int<lower=0, upper=1> holdout[N_obs];   // holdout for cross-validation
+  array[N_obs] int<lower=0, upper=1> holdout;   // holdout for cross-validation
 }
 
 transformed data {
   real<lower = 0> sigma_alpha_prior_rate = (2 - 1) / (B / 5.0);
   real<lower = 0> tau_prior_rate = (2 - 1) / (B / 5.0);
   vector<lower = -B, upper = B>[N] Vvec = to_vector(V);
-  real<lower = -B, upper = B> p[2, N_obs];
+  array[2, N_obs] real<lower = -B, upper = B> p;
   for (n in 1:N_obs) {
     p[1, n] = U[n] * V[ii[n]] + B * U[n] - B;
     p[2, n] = U[n] * V[ii[n]] - B * U[n] + B;
@@ -29,14 +29,14 @@ parameters {
   matrix[N, 2] alpha_raw;                 // shift parameter, split, raw
   matrix[N, 2] beta_raw;                  // stretch parameter, split, raw
   ordered[2] theta_lr;                    // left and right pole
-  real theta_raw[J];                      // remaining stimuli
+  array[J] real theta_raw;                      // remaining stimuli
   real<lower = 0> sigma_alpha;            // sd of alpha
   real<lower = 0, upper = 2> sigma_beta;  // sd of log(beta)
   real<lower = 0> tau;                    // sd of errors
   vector<lower = 0, upper = 1>[N] lambda; // mixing proportion, flipping
   real<lower = .5, upper = 1> psi;        // mean of prior on lambda
   real<lower = 2, upper = 100> delta;     // concentration of prior on lambda
-  real<lower = 0, upper = 1> gamma[N];    // rationalization per respondent
+  array[N] real<lower = 0, upper = 1> gamma;    // rationalization per respondent
   real<lower = 1> gam_a;                  // hyperparameter for gamma
   real<lower = 1> gam_b;                  // hyperparameter for gamma
   vector<lower = 0, upper = 1>[2 * B + 1] zeta; // direction of rationalization
@@ -46,7 +46,7 @@ transformed parameters {
   vector[4] log_probs;
   real<lower=0> alpha_lambda = delta * psi; // reparameterization
   real<lower=0> beta_lambda = delta * (1 - psi);
-  real theta[J];                          // latent stimuli position
+  array[J] real theta;                          // latent stimuli position
   matrix[N, 2] alpha0;                    // shift parameter, split
   matrix[N, 2] beta0;                     // stretch parameter, split
   matrix[N, 2] chi0;                      // latent respondent positions, split


### PR DESCRIPTION
Now that rstan 2.26 is available on CRAN we need to update the deprecated syntax in your package's Stan models, otherwise it will fail to install with an upcoming version of RStan. 

The following updates have been made:

- New array syntax

More information about the deprecated and removed syntax in Stan can be found here:
- https://mc-stan.org/docs/functions-reference/deprecated-functions.html
- https://mc-stan.org/docs/functions-reference/removed-functions.html

If you could merge and submit to CRAN soon, it would be greatly appreciated.

Let me know if you have any questions about these changes.

Thanks!
